### PR TITLE
Make expr optional in specials

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -122,28 +122,28 @@ module.exports = grammar({
     quote: $ => seq(
       '(',
       'quote',
-      $._expr,
+      optional($._expr),
       ')'
     ),
 
     splice: $ => seq(
       '(',
       'splice',
-      $._expr,
+      optional($._expr),
       ')'
     ),
 
     quasiquote: $ => seq(
       '(',
       'quasiquote',
-      $._expr,
+      optional($._expr),
       ')'
     ),
 
     unquote: $ => seq(
       '(',
       'unquote',
-      $._expr,
+      optional($._expr),
       ')'
     ),
 


### PR DESCRIPTION
Here's a draft PR.

I tested it against most of the janet repositories I have collected locally.

FWIW, the command I use for that is something like:
```
find ~/src/janet-repositories -type f -regex '.*\.janet$' -print0 | xargs -0 npx tree-sitter parse --quiet | wc -l
```